### PR TITLE
[Fix] Remove readme picture size

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 本项目利用A*算法和Dash框架，实现了中国前500城市之间铁路连接的最短路径求解和可视化。用户可以在界面中选择起点和终点，实时计算并显示最短路径，同时展示各个城市的铁路连接情况。
 <div style="display:flex; justify-content:center;">
-    <img src="image.png" alt="Image text" style="width:300px;">
+    <img src="image.png" alt="Image text">
 </div>
 
 ## 功能


### PR DESCRIPTION
Remove picture size to make it looks larger in `readme.md`.

Before:
<img width="672" alt="Snipaste_2024-06-05_21-51-57" src="https://github.com/Yuki-zik/railway-visualization/assets/36418285/62fee0d3-3bb6-4212-9a2f-899a29f16e06">
After:
<img width="672" alt="Snipaste_2024-06-05_21-52-59" src="https://github.com/Yuki-zik/railway-visualization/assets/36418285/667a6bbe-892e-452d-a26e-8e5d6bb571f6">
